### PR TITLE
NSDateFormatter tests pass incorrect dates

### DIFF
--- a/CocoaHelper.xcodeproj/project.pbxproj
+++ b/CocoaHelper.xcodeproj/project.pbxproj
@@ -529,6 +529,14 @@
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0500;
+				TargetAttributes = {
+					62421EDE17EE518000676DA7 = {
+						TestTargetID = 62421ED117EE518000676DA7;
+					};
+					62421F0817EE519900676DA7 = {
+						TestTargetID = 62421EF817EE519900676DA7;
+					};
+				};
 			};
 			buildConfigurationList = 62421E2317EE4FBF00676DA7 /* Build configuration list for PBXProject "CocoaHelper" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -822,6 +830,10 @@
 				INFOPLIST_FILE = "CocoaHelperTests/CocoaHelperTests-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				WRAPPER_EXTENSION = xctest;
@@ -863,6 +875,10 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "CocoaHelperTests/CocoaHelperTests-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;

--- a/CocoaHelper/NSDateFormatter+Extended.m
+++ b/CocoaHelper/NSDateFormatter+Extended.m
@@ -26,6 +26,8 @@
 
 @implementation NSDateFormatter (Extended)
 
+static NSString* const MainBundleIdentifier = @"com.michaelreneer.CocoaHelper";
+
 #pragma mark - Instance Methods
 
 + (NSString *)relativeDateAndTimeStringFromDate:(NSDate *)date {
@@ -38,12 +40,12 @@
             NSInteger hours = floor(interval / TimeIntervalOfOneHour * -1);
             
             if (hours == 1) {
-                NSString *hoursFormat = NSLocalizedString(@"HOUR_AGO", @"Format for the relative date and time string for a date equal to today and 1 hour ago.");
+                NSString *hoursFormat = NSLocalizedStringFromTableInBundle(@"HOUR_AGO", nil, [NSBundle bundleWithIdentifier:MainBundleIdentifier], @"Format for the relative date and time string for a date equal to today and 1 hour ago.");
                 
                 return [[NSString alloc] initWithFormat:hoursFormat, hours];
             }
             else {
-                NSString *hoursFormat = NSLocalizedString(@"HOURS_AGO", @"Format for the relative date and time string for a date equal to today and more than 1 hour ago.");
+                NSString *hoursFormat = NSLocalizedStringFromTableInBundle(@"HOURS_AGO", nil, [NSBundle bundleWithIdentifier:MainBundleIdentifier], @"Format for the relative date and time string for a date equal to today and more than 1 hour ago.");
                 
                 return [[NSString alloc] initWithFormat:hoursFormat, hours];
             }
@@ -52,12 +54,12 @@
             NSInteger minutes = floor(interval / TimeIntervalOfOneMinute * -1);
             
             if (minutes == 1) {
-                NSString *minutesFormat = NSLocalizedString(@"MINUTE_AGO", @"Format for the relative date and time string for a date equal to today and for 1 minute ago.");
+                NSString *minutesFormat = NSLocalizedStringFromTableInBundle(@"MINUTE_AGO", nil, [NSBundle bundleWithIdentifier:MainBundleIdentifier], @"Format for the relative date and time string for a date equal to today and for 1 minute ago.");
                 
                 return [[NSString alloc] initWithFormat:minutesFormat, minutes];
             }
             else {
-                NSString *minutesFormat = NSLocalizedString(@"MINUTES_AGO", @"Format for the relative date and time string for a date equal to today and for more than 1 minute ago.");
+                NSString *minutesFormat = NSLocalizedStringFromTableInBundle(@"MINUTES_AGO", nil, [NSBundle bundleWithIdentifier:MainBundleIdentifier], @"Format for the relative date and time string for a date equal to today and for more than 1 minute ago.");
                 
                 return [[NSString alloc] initWithFormat:minutesFormat, minutes];
             }
@@ -66,12 +68,12 @@
             NSInteger seconds = floor(interval / TimeIntervalOfOneSecond * -1);
             
             if (seconds == 1) {
-                NSString *secondsFormat = NSLocalizedString(@"SECOND_AGO", @"Format for the relative date and time string for a date equal to today and for 1 second ago.");
+                NSString *secondsFormat = NSLocalizedStringFromTableInBundle(@"SECOND_AGO", nil, [NSBundle bundleWithIdentifier:MainBundleIdentifier], @"Format for the relative date and time string for a date equal to today and for 1 second ago.");
                 
                 return [[NSString alloc] initWithFormat:secondsFormat, seconds];
             }
             else {
-                NSString *secondsFormat = NSLocalizedString(@"SECONDS_AGO", @"Format for the relative date and time string for a date equal to today and for more than 1 minute ago.");
+                NSString *secondsFormat = NSLocalizedStringFromTableInBundle(@"SECONDS_AGO", nil, [NSBundle bundleWithIdentifier:MainBundleIdentifier], @"Format for the relative date and time string for a date equal to today and for more than 1 minute ago.");
                 
                 return [[NSString alloc] initWithFormat:secondsFormat, seconds];
             }
@@ -80,12 +82,12 @@
             NSInteger hours = floor(interval / TimeIntervalOfOneHour);
             
             if (hours == 1) {
-                NSString *format = NSLocalizedString(@"HOUR_FROM_NOW", @"Format for the relative date and time string for a date equal to today and for 1 hour from now.");
+                NSString *format = NSLocalizedStringFromTableInBundle(@"HOUR_FROM_NOW", nil, [NSBundle bundleWithIdentifier:MainBundleIdentifier], @"Format for the relative date and time string for a date equal to today and for 1 hour from now.");
                 
                 return [[NSString alloc] initWithFormat:format, hours];
             }
             else {
-                NSString *format = NSLocalizedString(@"HOURS_FROM_NOW", @"Format for the relative date and time string for a date equal to today and for more than 1 hour from now.");
+                NSString *format = NSLocalizedStringFromTableInBundle(@"HOURS_FROM_NOW", nil, [NSBundle bundleWithIdentifier:MainBundleIdentifier], @"Format for the relative date and time string for a date equal to today and for more than 1 hour from now.");
                 
                 return [[NSString alloc] initWithFormat:format, hours];
             }
@@ -94,12 +96,12 @@
             NSInteger minutes = floor(interval / TimeIntervalOfOneMinute);
             
             if (minutes == 1) {
-                NSString *format = NSLocalizedString(@"MINUTE_FROM_NOW", @"Format for the relative date and time string for a date equal to today and for 1 minute from now.");
+                NSString *format = NSLocalizedStringFromTableInBundle(@"MINUTE_FROM_NOW", nil, [NSBundle bundleWithIdentifier:MainBundleIdentifier], @"Format for the relative date and time string for a date equal to today and for 1 minute from now.");
                 
                 return [[NSString alloc] initWithFormat:format, minutes];
             }
             else {
-                NSString *format = NSLocalizedString(@"MINUTES_FROM_NOW", @"Format for the relative date and time string for a date equal to today and for more than 1 minute from now.");
+                NSString *format = NSLocalizedStringFromTableInBundle(@"MINUTES_FROM_NOW", nil, [NSBundle bundleWithIdentifier:MainBundleIdentifier], @"Format for the relative date and time string for a date equal to today and for more than 1 minute from now.");
                 
                 return [[NSString alloc] initWithFormat:format, minutes];
             }
@@ -108,18 +110,18 @@
             NSInteger seconds = floor(interval / TimeIntervalOfOneSecond);
             
             if (seconds == 1) {
-                NSString *format = NSLocalizedString(@"SECOND_FROM_NOW", @"Format for the relative date and time string for a date equal to today and for 1 second from now.");
+                NSString *format = NSLocalizedStringFromTableInBundle(@"SECOND_FROM_NOW", nil, [NSBundle bundleWithIdentifier:MainBundleIdentifier], @"Format for the relative date and time string for a date equal to today and for 1 second from now.");
                 
                 return [[NSString alloc] initWithFormat:format, seconds];
             }
             else {
-                NSString *format = NSLocalizedString(@"SECONDS_FROM_NOW", @"Format for the relative date and time string for a date equal to today and for more than 1 second from now.");
+                NSString *format = NSLocalizedStringFromTableInBundle(@"SECONDS_FROM_NOW", nil, [NSBundle bundleWithIdentifier:MainBundleIdentifier], @"Format for the relative date and time string for a date equal to today and for more than 1 second from now.");
                 
                 return [[NSString alloc] initWithFormat:format, seconds];
             }
         }
         else {
-            return NSLocalizedString(@"NOW", @"String for the relative date and time string for now.");
+            return NSLocalizedStringFromTableInBundle(@"NOW", nil, [NSBundle bundleWithIdentifier:MainBundleIdentifier], @"String for the relative date and time string for now.");
         }
     }
     else if ([day isEqualToYesterday]) {
@@ -155,13 +157,13 @@
     NSDate *day = [date beginningOfDay];
     
     if ([day isEqualToToday]) {
-        return NSLocalizedString(@"TODAY", @"String for relative date string for today.");
+        return NSLocalizedStringFromTableInBundle(@"TODAY", nil, [NSBundle bundleWithIdentifier:MainBundleIdentifier], @"String for relative date string for today.");
     }
     else if ([day isEqualToYesterday]) {
-        return NSLocalizedString(@"YESTERDAY", @"String for relative date string for yesterday.");
+        return NSLocalizedStringFromTableInBundle(@"YESTERDAY", nil, [NSBundle bundleWithIdentifier:MainBundleIdentifier], @"String for relative date string for yesterday.");
     }
     else if ([day isEqualToTomorrow]) {
-        return NSLocalizedString(@"TOMORROW", @"String for relative date string for tomorrow.");
+        return NSLocalizedStringFromTableInBundle(@"TOMORROW", nil, [NSBundle bundleWithIdentifier:MainBundleIdentifier], @"String for relative date string for tomorrow.");
     }
     else {
         NSInteger interval = floor(abs([date timeIntervalSinceNow]));
@@ -196,7 +198,7 @@
         NSLocale *locale = [NSLocale autoupdatingCurrentLocale];
         NSString *dateComponent = [NSDateFormatter dateFormatFromTemplate:@"MMMdyyyy" options:0 locale:locale];
         NSString *timeComponent = [NSDateFormatter dateFormatFromTemplate:@"hmma" options:0 locale:locale];
-        NSString *separator = NSLocalizedString(@"DATE_TIME_SEPARATOR", @"String for joining the date and time components of the date format string.");
+        NSString *separator = NSLocalizedStringFromTableInBundle(@"DATE_TIME_SEPARATOR", nil, [NSBundle bundleWithIdentifier:MainBundleIdentifier], @"String for joining the date and time components of the date format string.");
         NSString *dateFormat = [[NSString alloc] initWithFormat:@"%@'%@'%@", dateComponent, separator, timeComponent];
         formatter = [[NSDateFormatter alloc] init];
         [formatter setDateFormat:dateFormat];
@@ -230,8 +232,8 @@
     dispatch_block_t block = ^(void) {
         NSLocale *locale = [NSLocale autoupdatingCurrentLocale];
         NSString *timeComponent = [NSDateFormatter dateFormatFromTemplate:@"hmma" options:0 locale:locale];
-        NSString *separator = NSLocalizedString(@"DATE_TIME_SEPARATOR", @"String for joining the date and time components of the date format string.");
-        NSString *tomorrow = NSLocalizedString(@"TOMORROW", @"String for relative date string for tomorrow.");
+        NSString *separator = NSLocalizedStringFromTableInBundle(@"DATE_TIME_SEPARATOR", nil, [NSBundle bundleWithIdentifier:MainBundleIdentifier], @"String for joining the date and time components of the date format string.");
+        NSString *tomorrow = NSLocalizedStringFromTableInBundle(@"TOMORROW", nil, [NSBundle bundleWithIdentifier:MainBundleIdentifier], @"String for relative date string for tomorrow.");
         NSString *dateFormat = [[NSString alloc] initWithFormat:@"'%@%@'%@", tomorrow, separator, timeComponent];
         formatter = [[NSDateFormatter alloc] init];
         [formatter setDateFormat:dateFormat];
@@ -250,7 +252,7 @@
         NSLocale *locale = [NSLocale autoupdatingCurrentLocale];
         NSString *dateComponent = [NSDateFormatter dateFormatFromTemplate:@"EEEE" options:0 locale:locale];
         NSString *timeComponent = [NSDateFormatter dateFormatFromTemplate:@"hmma" options:0 locale:locale];
-        NSString *separator = NSLocalizedString(@"DATE_TIME_SEPARATOR", @"String for joining the date and time components of the date format string.");
+        NSString *separator = NSLocalizedStringFromTableInBundle(@"DATE_TIME_SEPARATOR", nil, [NSBundle bundleWithIdentifier:MainBundleIdentifier], @"String for joining the date and time components of the date format string.");
         NSString *dateFormat = [[NSString alloc] initWithFormat:@"%@'%@'%@", dateComponent, separator, timeComponent];
         formatter = [[NSDateFormatter alloc] init];
         [formatter setDateFormat:dateFormat];
@@ -284,8 +286,8 @@
     dispatch_block_t block = ^(void) {
         NSLocale *locale = [NSLocale autoupdatingCurrentLocale];
         NSString *timeComponent = [NSDateFormatter dateFormatFromTemplate:@"hmma" options:0 locale:locale];
-        NSString *separator = NSLocalizedString(@"DATE_TIME_SEPARATOR", @"String for joining the date and time components of the date format string.");
-        NSString *yesterday = NSLocalizedString(@"YESTERDAY", @"String for relative date string for yesterday.");
+        NSString *separator = NSLocalizedStringFromTableInBundle(@"DATE_TIME_SEPARATOR", nil, [NSBundle bundleWithIdentifier:MainBundleIdentifier], @"String for joining the date and time components of the date format string.");
+        NSString *yesterday = NSLocalizedStringFromTableInBundle(@"YESTERDAY", nil, [NSBundle bundleWithIdentifier:MainBundleIdentifier], @"String for relative date string for yesterday.");
         NSString *dateFormat = [[NSString alloc] initWithFormat:@"'%@%@'%@", yesterday, separator, timeComponent];
         formatter = [[NSDateFormatter alloc] init];
         [formatter setDateFormat:dateFormat];

--- a/CocoaHelper/NSDateFormatter+Extended.m
+++ b/CocoaHelper/NSDateFormatter+Extended.m
@@ -197,7 +197,7 @@
         NSString *dateComponent = [NSDateFormatter dateFormatFromTemplate:@"MMMdyyyy" options:0 locale:locale];
         NSString *timeComponent = [NSDateFormatter dateFormatFromTemplate:@"hmma" options:0 locale:locale];
         NSString *separator = NSLocalizedString(@"DATE_TIME_SEPARATOR", @"String for joining the date and time components of the date format string.");
-        NSString *dateFormat = [[NSString alloc] initWithFormat:@"%@%@%@", dateComponent, separator, timeComponent];
+        NSString *dateFormat = [[NSString alloc] initWithFormat:@"%@'%@'%@", dateComponent, separator, timeComponent];
         formatter = [[NSDateFormatter alloc] init];
         [formatter setDateFormat:dateFormat];
     };
@@ -232,7 +232,7 @@
         NSString *timeComponent = [NSDateFormatter dateFormatFromTemplate:@"hmma" options:0 locale:locale];
         NSString *separator = NSLocalizedString(@"DATE_TIME_SEPARATOR", @"String for joining the date and time components of the date format string.");
         NSString *tomorrow = NSLocalizedString(@"TOMORROW", @"String for relative date string for tomorrow.");
-        NSString *dateFormat = [[NSString alloc] initWithFormat:@"%@%@%@", tomorrow, separator, timeComponent];
+        NSString *dateFormat = [[NSString alloc] initWithFormat:@"'%@%@'%@", tomorrow, separator, timeComponent];
         formatter = [[NSDateFormatter alloc] init];
         [formatter setDateFormat:dateFormat];
     };
@@ -251,7 +251,7 @@
         NSString *dateComponent = [NSDateFormatter dateFormatFromTemplate:@"EEEE" options:0 locale:locale];
         NSString *timeComponent = [NSDateFormatter dateFormatFromTemplate:@"hmma" options:0 locale:locale];
         NSString *separator = NSLocalizedString(@"DATE_TIME_SEPARATOR", @"String for joining the date and time components of the date format string.");
-        NSString *dateFormat = [[NSString alloc] initWithFormat:@"%@%@%@", dateComponent, separator, timeComponent];
+        NSString *dateFormat = [[NSString alloc] initWithFormat:@"%@'%@'%@", dateComponent, separator, timeComponent];
         formatter = [[NSDateFormatter alloc] init];
         [formatter setDateFormat:dateFormat];
     };
@@ -286,7 +286,7 @@
         NSString *timeComponent = [NSDateFormatter dateFormatFromTemplate:@"hmma" options:0 locale:locale];
         NSString *separator = NSLocalizedString(@"DATE_TIME_SEPARATOR", @"String for joining the date and time components of the date format string.");
         NSString *yesterday = NSLocalizedString(@"YESTERDAY", @"String for relative date string for yesterday.");
-        NSString *dateFormat = [[NSString alloc] initWithFormat:@"%@%@%@", yesterday, separator, timeComponent];
+        NSString *dateFormat = [[NSString alloc] initWithFormat:@"'%@%@'%@", yesterday, separator, timeComponent];
         formatter = [[NSDateFormatter alloc] init];
         [formatter setDateFormat:dateFormat];
     };

--- a/CocoaHelperTests/NSDateFormatterExtendedTests.m
+++ b/CocoaHelperTests/NSDateFormatterExtendedTests.m
@@ -33,37 +33,46 @@
     actual = [NSDateFormatter relativeDateAndTimeStringFromDate:date];
     XCTAssertEqualObjects(actual, @"1 second ago");
     
-//    date = [[NSDate alloc] initWithTimeIntervalSinceNow:0.0f];
-//    actual = [NSDateFormatter relativeDateAndTimeStringFromDate:date];
-//    XCTAssertEqualObjects(actual, @"just now");
-//    
-//    date = [[NSDate alloc] initWithTimeIntervalSinceNow:0.0f + TimeIntervalOfOneSecond];
-//    actual = [NSDateFormatter relativeDateAndTimeStringFromDate:date];
-//    XCTAssertEqualObjects(actual, @"1 second from now");
-//    
-//    date = [[NSDate alloc] initWithTimeIntervalSinceNow:TimeIntervalOfOneMinute - TimeIntervalOfOneSecond];
-//    actual = [NSDateFormatter relativeDateAndTimeStringFromDate:date];
-//    XCTAssertEqualObjects(actual, @"59 seconds from now");
-//    
-//    date = [[NSDate alloc] initWithTimeIntervalSinceNow:TimeIntervalOfOneMinute];
-//    actual = [NSDateFormatter relativeDateAndTimeStringFromDate:date];
-//    XCTAssertEqualObjects(actual, @"1 minute from now");
-//    
-//    date = [[NSDate alloc] initWithTimeIntervalSinceNow:TimeIntervalOfOneMinute + TimeIntervalOfOneSecond];
-//    actual = [NSDateFormatter relativeDateAndTimeStringFromDate:date];
-//    XCTAssertEqualObjects(actual, @"1 minute from now");
-//    
-//    date = [[NSDate alloc] initWithTimeIntervalSinceNow:TimeIntervalOfOneHour - TimeIntervalOfOneMinute];
-//    actual = [NSDateFormatter relativeDateAndTimeStringFromDate:date];
-//    XCTAssertEqualObjects(actual, @"59 minutes from now");
-//    
-//    date = [[NSDate alloc] initWithTimeIntervalSinceNow:TimeIntervalOfOneHour];
-//    actual = [NSDateFormatter relativeDateAndTimeStringFromDate:date];
-//    XCTAssertEqualObjects(actual, @"1 hour from now");
-//    
-//    date = [[NSDate alloc] initWithTimeIntervalSinceNow:TimeIntervalOfOneHour + TimeIntervalOfOneMinute];
-//    actual = [NSDateFormatter relativeDateAndTimeStringFromDate:date];
-//    XCTAssertEqualObjects(actual, @"1 hour from now");
+    date = [[NSDate alloc] initWithTimeIntervalSinceNow:0.0f];
+    actual = [NSDateFormatter relativeDateAndTimeStringFromDate:date];
+    XCTAssertEqualObjects(actual, @"just now");
+    
+    date = [[NSDate alloc] initWithTimeIntervalSinceNow:0.0f + TimeIntervalOfOneSecond];
+    actual = [NSDateFormatter relativeDateAndTimeStringFromDate:date];
+    XCTAssertEqualObjects(actual, @"1 second from now");
+    
+    date = [[NSDate alloc] initWithTimeIntervalSinceNow:TimeIntervalOfOneMinute - TimeIntervalOfOneSecond];
+    actual = [NSDateFormatter relativeDateAndTimeStringFromDate:date];
+    XCTAssertEqualObjects(actual, @"59 seconds from now");
+    
+    date = [[NSDate alloc] initWithTimeIntervalSinceNow:TimeIntervalOfOneMinute];
+    actual = [NSDateFormatter relativeDateAndTimeStringFromDate:date];
+    XCTAssertEqualObjects(actual, @"1 minute from now");
+    
+    date = [[NSDate alloc] initWithTimeIntervalSinceNow:TimeIntervalOfOneMinute + TimeIntervalOfOneSecond];
+    actual = [NSDateFormatter relativeDateAndTimeStringFromDate:date];
+    XCTAssertEqualObjects(actual, @"1 minute from now");
+    
+    date = [[NSDate alloc] initWithTimeIntervalSinceNow:TimeIntervalOfOneHour - TimeIntervalOfOneMinute];
+    actual = [NSDateFormatter relativeDateAndTimeStringFromDate:date];
+    XCTAssertEqualObjects(actual, @"59 minutes from now");
+    
+    date = [[NSDate alloc] initWithTimeIntervalSinceNow:TimeIntervalOfOneHour];
+    actual = [NSDateFormatter relativeDateAndTimeStringFromDate:date];
+    XCTAssertEqualObjects(actual, @"1 hour from now");
+    
+    date = [[NSDate alloc] initWithTimeIntervalSinceNow:TimeIntervalOfOneHour + TimeIntervalOfOneMinute];
+    actual = [NSDateFormatter relativeDateAndTimeStringFromDate:date];
+    XCTAssertEqualObjects(actual, @"1 hour from now");
+    
+    date = [NSDate yesterday];
+    actual = [NSDateFormatter relativeDateAndTimeStringFromDate:date];
+    XCTAssertEqualObjects(actual, @"yesterday at 12:00 AM");
+    
+    date = [NSDate tomorrow];
+    actual = [NSDateFormatter relativeDateAndTimeStringFromDate:date];
+    XCTAssertEqualObjects(actual, @"tomorrow at 12:00 AM");
+    
 }
 
 //- (void)testRelativeDateOnlyStringFromDate {


### PR DESCRIPTION
When I investigated how Issue #2 passed the unit tests, I discovered it was because it wasn't being tested.

Obviously the NSDateFormatter tests haven't been implemented, or once were implemented and aren't currently working.

The major problem seems to be that the localized strings aren't read from the localizable.strings files for the iOS static library or the Mac OS framework. Instead of finding the localized string replacements, the name of the string (the key) is used instead, so obviously none of the tests can pass.

So, I used the following solution to ensure the tests passed correctly, but I'm not sure it's an optimal solution.

Essentially the bundle for the XCTest target has no localizable.strings files, so when running the unit tests, none of the localized strings are found in the main bundle.

If you instead point the NSDateFormatter extension methods directly to the library's/framework's bundle identifier, then the strings are able to be read out of the localizable.strings files in the library's/framework's bundle.

This change produced passing test results for all existing tests (including the ones that were previously commented out) and for new tests I added to test 'tomorrow' and 'yesterday' date strings. The new tests rely on using the English localization strings.

This implementation, however, has the horrific downside of hard-coding the main bundle identifier for the library/framework targets in the NSDateFormatter class extension. If you know of a way to add localizable.strings files to the XCTest target it would eliminate the need to change the NSDateFormatter methods. I'm unfamiliar with XCTest, so I couldn't figure it out.